### PR TITLE
Render chat stream container at stream start

### DIFF
--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -300,7 +300,7 @@ export function MarketChatbox({ marketId, marketQuestion }: MarketChatboxProps) 
               </div>
             </div>
           ))}
-          {(streamingReasoning || streamingContent) && (
+          {(streamingReasoning || streamingContent || isStreaming) && (
             <div className="space-y-2">
               {streamingReasoning && (
                 <div className="bg-yellow-100/50 border-l-4 border-yellow-400 p-3 rounded-lg">


### PR DESCRIPTION
## Summary
- render the streaming chat container as soon as a stream starts so refs are available immediately

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 135 problems (115 errors, 20 warnings))*
- `node test-snippet` (custom): verified `streamingContentRef` exists and chunks update progressively

------
https://chatgpt.com/codex/tasks/task_e_68903f05c0b883338f30e592c4987075