### PR TITLE
feat: send market description in market chat

### DIFF
--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -10,6 +10,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 interface MarketChatboxProps {
   marketId: string
   marketQuestion: string
+  marketDescription?: string
 }
 
 interface Message {
@@ -24,7 +25,7 @@ interface OpenRouterModel {
   description?: string
 }
 
-export function MarketChatbox({ marketId, marketQuestion }: MarketChatboxProps) {
+export function MarketChatbox({ marketId, marketQuestion, marketDescription }: MarketChatboxProps) {
   const [chatMessage, setChatMessage] = useState('')
   const [messages, setMessages] = useState<Message[]>([])
   const [hasStartedChat, setHasStartedChat] = useState(false)
@@ -239,6 +240,7 @@ export function MarketChatbox({ marketId, marketQuestion }: MarketChatboxProps) 
               userId: user?.id,
               marketId,
               marketQuestion,
+              marketDescription,
               selectedModel
             })
           }

--- a/src/components/market/MarketDetails.tsx
+++ b/src/components/market/MarketDetails.tsx
@@ -184,7 +184,7 @@ export function MarketDetails({
       )}
 
       <div className="mt-6">
-        <MarketChatbox marketId={marketId} marketQuestion={question} />
+        <MarketChatbox marketId={marketId} marketQuestion={question} marketDescription={description} />
       </div>
 
       {description && (

--- a/supabase/functions/market-chat/index.ts
+++ b/supabase/functions/market-chat/index.ts
@@ -15,13 +15,14 @@ serve(async (req) => {
   }
 
   try {
-    const { message, chatHistory, userId, marketId, marketQuestion, selectedModel } = await req.json()
-    console.log('Received market chat request:', { 
-      message, 
-      chatHistory, 
+    const { message, chatHistory, userId, marketId, marketQuestion, marketDescription, selectedModel } = await req.json()
+    console.log('Received market chat request:', {
+      message,
+      chatHistory,
       userId: userId ? 'provided' : 'not provided',
       marketId,
-      marketQuestion 
+      marketQuestion,
+      marketDescription: marketDescription ? 'provided' : 'not provided'
     })
 
     // Determine which API key to use
@@ -125,10 +126,11 @@ Current Market Data:
 - Best Bid: ${marketData.final_best_bid || 'N/A'}
 - Best Ask: ${marketData.final_best_ask || 'N/A'}
 - Tags: ${marketData.primary_tags ? marketData.primary_tags.join(', ') : 'N/A'}
-- Description: ${marketData.description ? marketData.description.substring(0, 300) + '...' : 'N/A'}
+- Description: ${(marketData.description || marketDescription) ? ( (marketData.description || marketDescription).substring(0, 300) + '...') : 'N/A'}
 - Outcomes: ${marketData.outcomes ? marketData.outcomes.join(' vs ') : 'N/A'}` : `
 Current Market Context:
 - Market Question: ${marketQuestion || 'Not specified'}
+- Market Description: ${marketDescription ? marketDescription.substring(0, 300) + '...' : 'Not specified'}
 - Market ID: ${marketId || 'Not specified'}`
 
     const systemPrompt = `You are a helpful market analysis assistant focused on prediction markets. 
@@ -157,6 +159,11 @@ Keep responses conversational and accessible while maintaining analytical depth.
       stream: true,
       reasoning: {
         maxTokens: 8000
+      },
+      info: {
+        marketId,
+        marketQuestion,
+        marketDescription: marketData?.description || marketDescription || undefined
       }
     }
     console.log('OpenRouter request body:', requestBody)


### PR DESCRIPTION
## Summary
- pass market descriptions through MarketDetails and MarketChatbox
- include descriptions in market chat edge function context and info payload for OpenRouter

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: multiple lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68904acab1e48333827a6c1dfe4c1a1e