### PR TITLE
Keep market chat stream alive until completion

### DIFF
--- a/supabase/functions/market-chat/index.ts
+++ b/supabase/functions/market-chat/index.ts
@@ -382,15 +382,13 @@ Keep responses conversational and accessible while maintaining analytical depth.
 
             edgeChunkCount++
             return pump()
-          }).catch(error => {
-            console.error(`[EDGE-ERROR] Error in pump function:`, error)
-            controller.error(error)
           })
         }
-        
-        // Start pumping immediately without waiting for completion
-        console.log('[STREAM-DEBUG] Starting pump without waiting for completion')
-        pump().catch(error => {
+
+        // Start pumping and return the promise so the runtime
+        // keeps the function alive until streaming completes
+        console.log('[STREAM-DEBUG] Starting pump and returning promise')
+        return pump().catch(error => {
           console.error('[STREAM-DEBUG] Pump error:', error)
           controller.error(error)
         })


### PR DESCRIPTION
## Summary
- ensure edge function returns the pumping promise so Supabase waits for streaming to finish

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 136 problems (116 errors, 20 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689059c7f3948333a98c29deb6f5567e