### PR TITLE
Stream reasoning tokens in market chat

### DIFF
--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -170,8 +170,8 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
             break
             
           case 'REASONING_CHUNK':
-            console.log('🧠 [WORKER-MSG] Received reasoning chunk - storing for final update')
-            // Don't update state during streaming to avoid React batching
+            console.log('🧠 [WORKER-MSG] Received reasoning chunk')
+            setStreamingReasoning(data.reasoning)
             break
             
           case 'STREAM_COMPLETE':


### PR DESCRIPTION
## Summary
- Display streaming reasoning tokens in MarketChatbox via worker messages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68905e2e3e388333acdc0a6af19aeaea