### PR TITLE
feat: allow saving and loading chat agents

### DIFF
--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -13,7 +13,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog"
 import { Textarea } from "@/components/ui/textarea"
 
@@ -425,20 +424,19 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
             </SelectContent>
           )}
         </Select>
-        <Dialog
-          open={isAgentDialogOpen}
-          onOpenChange={(open) => {
-            setIsAgentDialogOpen(open)
-            if (open) {
+        <Dialog open={isAgentDialogOpen} onOpenChange={setIsAgentDialogOpen}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-8 px-2 text-xs"
+            onClick={() => {
               setNewAgentModel(selectedModel)
-            }
-          }}
-        >
-          <DialogTrigger asChild>
-            <Button type="button" variant="ghost" size="sm" className="h-8 px-2 text-xs">
-              <BookmarkPlus className="w-4 h-4 mr-1" /> Add
-            </Button>
-          </DialogTrigger>
+              setIsAgentDialogOpen(true)
+            }}
+          >
+            <BookmarkPlus className="w-4 h-4 mr-1" /> Add
+          </Button>
           <DialogContent>
             <DialogHeader>
               <DialogTitle>Save New Agent</DialogTitle>


### PR DESCRIPTION
## Summary
- add agent storage and selection to MarketChatbox
- allow saving prompt/model pairs as agents and reloading them
- add dialog to create new agents directly in chat

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 136 problems)


------
https://chatgpt.com/codex/tasks/task_e_6890625c65c4833390afd0f7f7899a36