### PR TITLE
refactor chat history handling

### DIFF
--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -300,7 +300,7 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
             },
             body: JSON.stringify({
               message: userMessage,
-              chatHistory: messages.map(m => `${m.type}: ${m.content}`).join('\n'),
+              chatHistory: messages.map(m => ({ role: m.type, content: m.content })),
               userId: user?.id,
               marketId,
               marketQuestion,

--- a/supabase/functions/market-chat/index.ts
+++ b/supabase/functions/market-chat/index.ts
@@ -15,10 +15,10 @@ serve(async (req) => {
   }
 
   try {
-    const { message, chatHistory, userId, marketId, marketQuestion, marketDescription, selectedModel } = await req.json()
+    const { message, chatHistory = [], userId, marketId, marketQuestion, marketDescription, selectedModel } = await req.json()
     console.log('Received market chat request:', {
       message,
-      chatHistory,
+      chatHistoryLength: Array.isArray(chatHistory) ? chatHistory.length : 'invalid',
       userId: userId ? 'provided' : 'not provided',
       marketId,
       marketQuestion,
@@ -173,6 +173,7 @@ Keep responses conversational and accessible while maintaining analytical depth.
 
     console.log('Making request to OpenRouter API...')
     const fetchStart = performance.now()
+    const historyMessages = Array.isArray(chatHistory) ? chatHistory : []
     const requestBody = {
       model: selectedModel || "perplexity/sonar",
       messages: [
@@ -180,9 +181,10 @@ Keep responses conversational and accessible while maintaining analytical depth.
           role: "system",
           content: systemPrompt
         },
+        ...historyMessages,
         {
           role: "user",
-          content: `Chat History:\n${chatHistory || 'No previous chat history'}\n\nCurrent Query: ${message}`
+          content: message
         }
       ],
       stream: true,


### PR DESCRIPTION
## Summary
- send chat history as discrete message objects from client
- forward chat history directly to OpenRouter in backend

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 136 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68906ec20e4883338ed744d3e54e30a8