### PR TITLE
refactor chat history handling

### DIFF
--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -300,7 +300,7 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
             },
             body: JSON.stringify({
               message: userMessage,
-              chatHistory: messages.map(m => `${m.type}: ${m.content}`).join('\n'),
+              chatHistory: messages.map(m => ({ role: m.type, content: m.content })),
               userId: user?.id,
               marketId,
               marketQuestion,


### PR DESCRIPTION
## Summary
- send chat history as discrete message objects from client
- forward chat history directly to OpenRouter in backend
- adjust system prompt to prioritize the user's latest message and return relevant sources on the first reply

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 136 problems (116 errors, 20 warnings))*


------
https://chatgpt.com/codex/tasks/task_e_68906ec20e4883338ed744d3e54e30a8