### PR TITLE
Add market context to initial chat exchanges

### DIFF
--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -287,6 +287,13 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
         throw new Error("No authentication token available")
       }
       
+      const baseHistory = messages.map(m => ({ role: m.type, content: m.content }))
+      const marketContextMessage = {
+        role: 'assistant' as const,
+        content: `Current Market Context:\n- Market Question: ${marketQuestion || 'Not specified'}\n- Market Description: ${marketDescription ? marketDescription.substring(0, 300) + '...' : 'Not specified'}\n- Market ID: ${marketId || 'Not specified'}`
+      }
+      const chatHistoryWithContext = baseHistory.length === 0 ? [marketContextMessage] : baseHistory
+
       worker.postMessage({
         type: 'START_STREAM',
         data: {
@@ -300,7 +307,7 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
             },
             body: JSON.stringify({
               message: userMessage,
-              chatHistory: messages.map(m => ({ role: m.type, content: m.content })),
+              chatHistory: chatHistoryWithContext,
               userId: user?.id,
               marketId,
               marketQuestion,

--- a/supabase/functions/market-chat/index.ts
+++ b/supabase/functions/market-chat/index.ts
@@ -162,8 +162,7 @@ Current Market Context:
 - Market Description: ${marketDescription ? marketDescription.substring(0, 300) + '...' : 'Not specified'}
 - Market ID: ${marketId || 'Not specified'}`
 
-    const systemPrompt = `You are a helpful market analysis assistant focused on prediction markets. Use the market information below only as background context and always prioritize the user's most recent question when generating search queries and responses.
-${marketContext}
+    const systemPrompt = `You are a helpful market analysis assistant focused on prediction markets. Use any market information provided in the conversation as background context and always prioritize the user's most recent question when generating search queries and responses.
 
 In your first reply, surface the most relevant and up-to-date online sources, citing each with a URL. Provide concise insights on how the information affects the market outcome. Keep responses conversational, informative, and analytically focused.`
 
@@ -176,6 +175,10 @@ In your first reply, surface the most relevant and up-to-date online sources, ci
         {
           role: "system",
           content: systemPrompt
+        },
+        {
+          role: "assistant",
+          content: marketContext
         },
         ...historyMessages,
         {


### PR DESCRIPTION
## Summary
- send market context as an assistant message before user prompts in market-chat function
- include pre-chat market context in first chat request from MarketChatbox

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_6890754ba0a88333bd96dd6ef5110ec0