### PR TITLE
Show incoming agent routes in chain builder and add agent_chains table

### DIFF
--- a/src/components/market/AgentChainDialog.tsx
+++ b/src/components/market/AgentChainDialog.tsx
@@ -87,6 +87,13 @@ export function AgentChainDialog({ open, onOpenChange, agents }: AgentChainDialo
     }))
   }
 
+  const getIncomingAgents = (layerIndex: number, agentIndex: number) => {
+    if (layerIndex === 0) return []
+    return layers[layerIndex - 1].agents
+      .map((agent, idx) => agent.routes?.includes(agentIndex) ? idx + 1 : null)
+      .filter((idx): idx is number => idx !== null)
+  }
+
   const reset = () => {
     setChainName('')
     setLayers([{ agents: [{ agentId: '', prompt: '', copies: 1 }] }])
@@ -133,46 +140,54 @@ export function AgentChainDialog({ open, onOpenChange, agents }: AgentChainDialo
                 )}
               </div>
 
-              {layer.agents.map((agent, agentIndex) => (
-                <div key={agentIndex} className="border p-3 rounded-md space-y-2">
-                  <div className="flex items-center gap-2">
-                    <Select
-                      value={agent.agentId}
-                      onValueChange={(val) => updateAgentBlock(layerIndex, agentIndex, 'agentId', val)}
-                    >
-                      <SelectTrigger className="w-[200px]">
-                        <SelectValue placeholder="Select agent" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {agents.map(a => (
-                          <SelectItem key={a.id} value={a.id} className="text-xs">
-                            {a.prompt.slice(0, 30)}...
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <Input
-                      type="number"
-                      min={1}
-                      value={agent.copies}
-                      onChange={(e) => updateAgentBlock(layerIndex, agentIndex, 'copies', parseInt(e.target.value))}
-                      className="w-16"
+              {layer.agents.map((agent, agentIndex) => {
+                const incoming = getIncomingAgents(layerIndex, agentIndex)
+                return (
+                  <div key={agentIndex} className="border p-3 rounded-md space-y-2">
+                    <div className="flex items-center gap-2">
+                      <Select
+                        value={agent.agentId}
+                        onValueChange={(val) => updateAgentBlock(layerIndex, agentIndex, 'agentId', val)}
+                      >
+                        <SelectTrigger className="w-[200px]">
+                          <SelectValue placeholder="Select agent" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {agents.map(a => (
+                            <SelectItem key={a.id} value={a.id} className="text-xs">
+                              {a.prompt.slice(0, 30)}...
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Input
+                        type="number"
+                        min={1}
+                        value={agent.copies}
+                        onChange={(e) => updateAgentBlock(layerIndex, agentIndex, 'copies', parseInt(e.target.value))}
+                        className="w-16"
+                      />
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => removeAgentFromLayer(layerIndex, agentIndex)}
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </Button>
+                    </div>
+                    {incoming.length > 0 && (
+                      <div className="text-xs text-muted-foreground">
+                        Receives output from agent(s): {incoming.join(', ')}
+                      </div>
+                    )}
+                    <Textarea
+                      placeholder="Custom prompt (optional)"
+                      value={agent.prompt}
+                      onChange={(e) => updateAgentBlock(layerIndex, agentIndex, 'prompt', e.target.value)}
                     />
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => removeAgentFromLayer(layerIndex, agentIndex)}
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </Button>
                   </div>
-                  <Textarea
-                    placeholder="Custom prompt (optional)"
-                    value={agent.prompt}
-                    onChange={(e) => updateAgentBlock(layerIndex, agentIndex, 'prompt', e.target.value)}
-                  />
-                </div>
-              ))}
+                )
+              })}
 
               <Button variant="secondary" size="sm" onClick={() => addAgentToLayer(layerIndex)}>
                 <Plus className="w-4 h-4 mr-1" /> Add agent

--- a/supabase/migrations/20250811000000_create_agent_chains.sql
+++ b/supabase/migrations/20250811000000_create_agent_chains.sql
@@ -1,0 +1,17 @@
+-- Create table for storing agent chains
+create table if not exists public.agent_chains (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references auth.users not null,
+  name text not null,
+  config jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+-- Enable Row Level Security
+alter table public.agent_chains enable row level security;
+
+-- Allow users to manage their own agent chains
+create policy "Users can manage their own agent chains" on public.agent_chains
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- show when an agent receives output from a previous layer in agent chains
- add migration to create `agent_chains` table for saving chains

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 136 problems (116 errors, 20 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689085472068833397fd94ccbfb14889