### PR TITLE
Show incoming agent routes in chain builder and add agent_chains table

### DIFF
--- a/supabase/migrations/20250811000000_create_agent_chains.sql
+++ b/supabase/migrations/20250811000000_create_agent_chains.sql
@@ -1,0 +1,17 @@
+-- Create table for storing agent chains
+create table if not exists public.agent_chains (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references auth.users not null,
+  name text not null,
+  config jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+-- Enable Row Level Security
+alter table public.agent_chains enable row level security;
+
+-- Allow users to manage their own agent chains
+create policy "Users can manage their own agent chains" on public.agent_chains
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- show when an agent receives output from a previous layer in agent chains
- add migration to create `agent_chains` table for saving chains
- fetch and display the current user's saved agent chains

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 137 problems (117 errors, 20 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689085472068833397fd94ccbfb14889