### PR TITLE
Enable agent chain execution in Market Chat

### DIFF
--- a/src/utils/executeAgentChain.ts
+++ b/src/utils/executeAgentChain.ts
@@ -15,7 +15,7 @@ interface Layer {
   agents: AgentBlock[]
 }
 
-interface ChainConfig {
+export interface ChainConfig {
   layers: Layer[]
 }
 


### PR DESCRIPTION
## Summary
- trigger agent chains when selected in Market Chat
- run chain logic without manual input to mirror agent behavior
- export ChainConfig type for typed chain configuration

## Testing
- `npx eslint src/components/market/MarketChatbox.tsx`
- `npx eslint src/utils/executeAgentChain.ts`


------
https://chatgpt.com/codex/tasks/task_e_6890ec7791f883338faa21921c9c4142