### PR TITLE
Print outputs for each agent and stream chunks in real time

### DIFF
--- a/public/streaming-worker.js
+++ b/public/streaming-worker.js
@@ -3,43 +3,7 @@
 
 self.onmessage = async function(e) {
   const { type, data } = e.data;
-  
-  if (type === 'TEST_CHUNKS') {
-    console.log('🧪 [WORKER] Starting test chunk sequence');
-    
-    // Send test chunks to verify real-time updates
-    const testChunks = ['Hello', ' there!', ' This', ' is', ' a', ' test', ' of', ' real-time', ' streaming.'];
-    
-    for (let i = 0; i < testChunks.length; i++) {
-      const chunk = testChunks[i];
-      const accumulated = testChunks.slice(0, i + 1).join('');
-      
-      console.log(`📦 [WORKER] Test chunk ${i + 1}/${testChunks.length}: "${chunk}"`);
-      console.log(`📝 [WORKER] Accumulated so far: "${accumulated}"`);
-      
-      self.postMessage({
-        type: 'CONTENT_CHUNK',
-        data: { 
-          content: accumulated,
-          newChunk: chunk
-        }
-      });
-      
-      // Wait 500ms between chunks to simulate real streaming
-      await new Promise(resolve => setTimeout(resolve, 500));
-    }
-    
-    console.log('🏁 [WORKER] Test sequence complete');
-    self.postMessage({
-      type: 'STREAM_COMPLETE',
-      data: { 
-        content: testChunks.join(''),
-        reasoning: '' 
-      }
-    });
-    return;
-  }
-  
+
   if (type === 'START_STREAM') {
     const { url, options } = data;
     

--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -312,6 +312,13 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
             authToken
           }
         )
+        if (result.outputs && result.outputs.length > 0) {
+          const chainMessages = result.outputs.map(o => ({
+            type: 'assistant' as const,
+            content: `Agent ${o.agentId}: ${o.output}`
+          }))
+          setMessages(prev => [...prev, ...chainMessages])
+        }
         finalPrompt = result.prompt
         finalModel = result.model
       }


### PR DESCRIPTION
## Summary
- process streaming chunks on-the-fly when calling models
- collect and return every agent's output for display
- stream directly from edge function without simulated test chunks

## Testing
- `npm run lint` *(fails: Unexpected any ...)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890fb3257348333b92d7838072c0634