### PR TITLE
Print outputs for each agent and stream chunks in real time

### DIFF
--- a/public/streaming-worker.js
+++ b/public/streaming-worker.js
@@ -3,43 +3,7 @@
 
 self.onmessage = async function(e) {
   const { type, data } = e.data;
-  
-  if (type === 'TEST_CHUNKS') {
-    console.log('🧪 [WORKER] Starting test chunk sequence');
-    
-    // Send test chunks to verify real-time updates
-    const testChunks = ['Hello', ' there!', ' This', ' is', ' a', ' test', ' of', ' real-time', ' streaming.'];
-    
-    for (let i = 0; i < testChunks.length; i++) {
-      const chunk = testChunks[i];
-      const accumulated = testChunks.slice(0, i + 1).join('');
-      
-      console.log(`📦 [WORKER] Test chunk ${i + 1}/${testChunks.length}: "${chunk}"`);
-      console.log(`📝 [WORKER] Accumulated so far: "${accumulated}"`);
-      
-      self.postMessage({
-        type: 'CONTENT_CHUNK',
-        data: { 
-          content: accumulated,
-          newChunk: chunk
-        }
-      });
-      
-      // Wait 500ms between chunks to simulate real streaming
-      await new Promise(resolve => setTimeout(resolve, 500));
-    }
-    
-    console.log('🏁 [WORKER] Test sequence complete');
-    self.postMessage({
-      type: 'STREAM_COMPLETE',
-      data: { 
-        content: testChunks.join(''),
-        reasoning: '' 
-      }
-    });
-    return;
-  }
-  
+
   if (type === 'START_STREAM') {
     const { url, options } = data;
     

--- a/src/utils/executeAgentChain.ts
+++ b/src/utils/executeAgentChain.ts
@@ -19,6 +19,12 @@ export interface ChainConfig {
   layers: Layer[]
 }
 
+export interface AgentOutput {
+  layer: number
+  agentId: string
+  output: string
+}
+
 interface ExecutionContext {
   userId?: string
   marketId: string
@@ -59,25 +65,31 @@ async function callModel(prompt: string, model: string, context: ExecutionContex
 
   const reader = res.body.getReader()
   const decoder = new TextDecoder()
-  let result = ""
+  let buffer = ""
+  let content = ""
+
   while (true) {
     const { value, done } = await reader.read()
     if (done) break
-    result += decoder.decode(value, { stream: true })
-  }
+    buffer += decoder.decode(value, { stream: true })
 
-  console.log('📨 [callModel] Raw response:', result)
-  const lines = result.split("\n")
-  let content = ""
-  for (const line of lines) {
-    if (line.startsWith("data:")) {
-      const jsonStr = line.replace(/^data:\s*/, "").trim()
-      if (jsonStr === "[DONE]") break
-      try {
-        const parsed = JSON.parse(jsonStr)
-        content += parsed.choices?.[0]?.delta?.content || ""
-      } catch {
-        // ignore parsing errors
+    const lines = buffer.split("\n")
+    buffer = lines.pop() || ""
+
+    for (const line of lines) {
+      if (line.startsWith("data:")) {
+        const jsonStr = line.replace(/^data:\s*/, "").trim()
+        if (jsonStr === "[DONE]") continue
+        try {
+          const parsed = JSON.parse(jsonStr)
+          const chunk = parsed.choices?.[0]?.delta?.content || ""
+          if (chunk) {
+            content += chunk
+            console.log('✂️ [callModel] Received chunk:', chunk)
+          }
+        } catch {
+          // ignore parsing errors
+        }
       }
     }
   }
@@ -91,7 +103,7 @@ export async function executeAgentChain(
   agents: Agent[],
   initialInput: string,
   context: ExecutionContext
-): Promise<{ prompt: string; model: string }> {
+): Promise<{ prompt: string; model: string; outputs: AgentOutput[]; finalAgentId: string }> {
   console.log('🚀 [executeAgentChain] Starting chain execution')
   console.log('🚀 [executeAgentChain] Chain config:', JSON.stringify(chainConfig, null, 2))
   console.log('🚀 [executeAgentChain] Initial input:', initialInput)
@@ -100,6 +112,7 @@ export async function executeAgentChain(
   }
 
   let currentInputs: string[] = chainConfig.layers[0].agents.map(() => initialInput)
+  const agentOutputs: AgentOutput[] = []
 
   for (let i = 0; i < chainConfig.layers.length - 1; i++) {
     const layer = chainConfig.layers[i]
@@ -126,6 +139,7 @@ export async function executeAgentChain(
         console.log(`📡 [executeAgentChain] Calling model for agent ${agent.id}, copy ${c + 1}`)
         const output = await callModel(`${basePrompt}\n\n${input}`, agent.model, context)
         console.log(`📦 [executeAgentChain] Output from agent ${agent.id}:`, output)
+        agentOutputs.push({ layer: i + 1, agentId: agent.id, output })
         if (block.routes && block.routes.length > 0) {
           for (const target of block.routes) {
             nextInputs[target] = [nextInputs[target], output].filter(Boolean).join("\n")
@@ -161,6 +175,8 @@ export async function executeAgentChain(
   return {
     prompt: `${finalPromptBase}\n\n${finalInput}`.trim(),
     model: finalAgent.model,
+    outputs: agentOutputs,
+    finalAgentId: finalAgent.id,
   }
 }
 


### PR DESCRIPTION
## Summary
- process streaming chunks on-the-fly when calling models
- collect and return every agent's output for display
- stream directly from edge function without simulated test chunks
- label streamed output with the final agent's ID for clarity

## Testing
- `npm run lint` *(fails: 'allMarkets' is never reassigned, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890fb3257348333b92d7838072c0634