### PR TITLE
Display all intermediate agent outputs

### DIFF
--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -318,7 +318,6 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
 
         if (result.outputs && result.outputs.length > 0) {
           const chainMessages = result.outputs
-            .filter(o => o.agentId !== finalAgentId)
             .map(o => ({
               type: 'assistant' as const,
               content: `Agent ${o.agentId}: ${o.output}`


### PR DESCRIPTION
## Summary
- show outputs from all chain agents even when agent IDs repeat

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689108f5b71083339f41d749647d46e9