### PR TITLE
feat: show intermediate agent outputs by layer

### DIFF
--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -317,8 +317,11 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
         finalAgentId = chain.config.layers.at(-1)?.agents[0]?.agentId
 
         if (result.outputs && result.outputs.length > 0) {
+          const finalLayerIndex = chain.config.layers.length
+          // Filter out outputs from the final layer rather than by agent ID
+          // so intermediate results are preserved even if agent IDs repeat
           const chainMessages = result.outputs
-            .filter(o => o.agentId !== finalAgentId)
+            .filter(o => o.layer !== finalLayerIndex)
             .map(o => ({
               type: 'assistant' as const,
               content: `Agent ${o.agentId}: ${o.output}`


### PR DESCRIPTION
## Summary
- stop filtering intermediate messages by agent id
- filter out final layer's output to preserve earlier responses even when agent ids repeat

## Testing
- `npx eslint src/components/market/MarketChatbox.tsx`
- `npm run lint` *(fails: 131 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68910bbcea288333b7bfd490914eed66