### PR TITLE
fix: filter final layer outputs

### DIFF
--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -317,11 +317,11 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
         finalAgentId = chain.config.layers.at(-1)?.agents[0]?.agentId
 
         if (result.outputs && result.outputs.length > 0) {
-          const finalLayerIndex = chain.config.layers.length
+          const finalLayerIdx = chain.config.layers.length - 1
           // Filter out outputs from the final layer rather than by agent ID
           // so intermediate results are preserved even if agent IDs repeat
           const chainMessages = result.outputs
-            .filter(o => o.layer !== finalLayerIndex)
+            .filter(o => o.layer !== finalLayerIdx)
             .map(o => ({
               type: 'assistant' as const,
               content: `Agent ${o.agentId}: ${o.output}`


### PR DESCRIPTION
## Summary
- ensure MarketChatbox ignores final layer outputs when displaying chain intermediates

## Testing
- `npm run lint` *(fails: prefer-const, no-explicit-any, etc.)*
- `npx eslint src/components/market/MarketChatbox.tsx`
- `node -e "const chain={config:{layers:[{}, {}, {}]}}; const finalLayerIdx=chain.config.layers.length - 1; const result={outputs:[{layer:0,agentId:'a',output:'out0'},{layer:1,agentId:'b',output:'out1'},{layer:2,agentId:'c',output:'out2'}]}; const msgs=result.outputs.filter(o=>o.layer !== finalLayerIdx).map(o=> 'Agent '+o.agentId+': '+o.output); console.log(msgs);"`

------
https://chatgpt.com/codex/tasks/task_e_689111c363688333beae128aeed4c00b