### PR TITLE
fix: align agent layer indexing

### DIFF
--- a/src/utils/executeAgentChain.ts
+++ b/src/utils/executeAgentChain.ts
@@ -158,7 +158,7 @@ export async function executeAgentChain(
           (chunk) => {
             streamed += chunk
             onAgentStream?.({
-              layer: i + 1,
+              layer: i,
               agentId: agent.id,
               copy: c + 1,
               content: streamed,
@@ -168,9 +168,9 @@ export async function executeAgentChain(
         )
         streamed = output
         console.log(`📦 [executeAgentChain] Output from agent ${agent.id}:`, output)
-        agentOutputs.push({ layer: i + 1, agentId: agent.id, output })
+        agentOutputs.push({ layer: i, agentId: agent.id, output })
         onAgentStream?.({
-          layer: i + 1,
+          layer: i,
           agentId: agent.id,
           copy: c + 1,
           content: output,


### PR DESCRIPTION
## Summary
- ensure agent layers are zero-indexed to avoid filtering out first layer output

## Testing
- `npm run lint` *(fails: 131 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68915ece9cb0833380c348c271f79dfa