### PR TITLE
feat: enable streaming for agent chain

### DIFF
--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -167,7 +167,7 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
   }, [fetchChains])
 
   const handleAgentStream = useCallback(
-    (
+    async (
       { agentId, layer, copy, content, isFinal }: { agentId: string; layer: number; copy: number; content: string; isFinal: boolean }
     ) => {
       const key = `${layer}-${agentId}-${copy}`
@@ -181,11 +181,19 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
             return msgs
           })
         })
+        // ensure DOM refs are available before streaming starts
+        await new Promise(requestAnimationFrame)
       }
 
-      const container = agentStreamingRefs.current[key]
+      const waitForContainer = async () => {
+        while (!agentStreamingRefs.current[key]) {
+          await new Promise(requestAnimationFrame)
+        }
+        return agentStreamingRefs.current[key]!
+      }
 
       if (isFinal) {
+        const container = await waitForContainer()
         flushSync(() => {
           setMessages(prev => {
             const msgs = [...prev]
@@ -196,23 +204,26 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
             return msgs
           })
         })
-        if (container) container.innerHTML = ''
+        container.innerHTML = ''
         delete agentStreamingRefs.current[key]
         delete agentStreamIndices.current[key]
         return
       }
 
-      if (container) {
-        flushSync(() => {
-          const cursor = '<span class="inline-block w-2 h-4 bg-primary ml-1 animate-pulse">|</span>'
-          container.innerHTML = `<div class="text-sm whitespace-pre-wrap">Agent ${agentId}: ${content}${cursor}</div>`
-        })
-        requestAnimationFrame(() => {
-          if (agentStreamingRefs.current[key]) {
-            void agentStreamingRefs.current[key]!.offsetHeight
-          }
-        })
+      if (!content) {
+        return
       }
+
+      const container = await waitForContainer()
+      flushSync(() => {
+        const cursor = '<span class="inline-block w-2 h-4 bg-primary ml-1 animate-pulse">|</span>'
+        container.innerHTML = `<div class="text-sm whitespace-pre-wrap">Agent ${agentId}: ${content}${cursor}</div>`
+      })
+      requestAnimationFrame(() => {
+        if (agentStreamingRefs.current[key]) {
+          void agentStreamingRefs.current[key]!.offsetHeight
+        }
+      })
     },
     []
   )

--- a/src/utils/executeAgentChain.ts
+++ b/src/utils/executeAgentChain.ts
@@ -37,7 +37,7 @@ async function callModel(
   prompt: string,
   model: string,
   context: ExecutionContext,
-  onToken?: (chunk: string) => void
+  onToken?: (chunk: string) => void | Promise<void>
 ): Promise<string> {
   console.log('🧠 [callModel] Invoking model', model)
   console.log('🧠 [callModel] Prompt:', prompt)
@@ -91,7 +91,7 @@ async function callModel(
           if (chunk) {
             content += chunk
             console.log('✂️ [callModel] Received chunk:', chunk)
-            onToken?.(chunk)
+            await onToken?.(chunk)
           }
         } catch {
           // ignore parsing errors
@@ -115,7 +115,7 @@ export async function executeAgentChain(
     copy: number
     content: string
     isFinal: boolean
-  }) => void
+  }) => void | Promise<void>
 ): Promise<{ prompt: string; model: string; outputs: AgentOutput[] }> {
   console.log('🚀 [executeAgentChain] Starting chain execution')
   console.log('🚀 [executeAgentChain] Chain config:', JSON.stringify(chainConfig, null, 2))
@@ -151,13 +151,20 @@ export async function executeAgentChain(
       for (let c = 0; c < (block.copies || 1); c++) {
         console.log(`📡 [executeAgentChain] Calling model for agent ${agent.id}, copy ${c + 1}`)
         let streamed = ""
+        onAgentStream?.({
+          layer: i,
+          agentId: agent.id,
+          copy: c + 1,
+          content: "",
+          isFinal: false,
+        })
         const output = await callModel(
           `${basePrompt}\n\n${input}`,
           agent.model,
           context,
-          (chunk) => {
+          async (chunk) => {
             streamed += chunk
-            onAgentStream?.({
+            await onAgentStream?.({
               layer: i,
               agentId: agent.id,
               copy: c + 1,
@@ -169,7 +176,7 @@ export async function executeAgentChain(
         streamed = output
         console.log(`📦 [executeAgentChain] Output from agent ${agent.id}:`, output)
         agentOutputs.push({ layer: i, agentId: agent.id, output })
-        onAgentStream?.({
+        await onAgentStream?.({
           layer: i,
           agentId: agent.id,
           copy: c + 1,


### PR DESCRIPTION
## Summary
- send an initial empty stream update before each agent model call so the UI can render placeholders
- support async token callbacks and stream updates so agents produce partial tokens as they arrive
- make `handleAgentStream` wait for DOM readiness and ignore empty updates for smooth streaming
- ensure all agents stream by not awaiting placeholder callbacks and waiting a frame for DOM refs before processing chunks

## Testing
- `npm run lint` *(fails: prefer-const, no-explicit-any, etc.)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891de40127c8333a14a0a864e090617