### PR TITLE
Ensure agent stream placeholder renders before streaming output

### DIFF
--- a/src/utils/executeAgentChain.ts
+++ b/src/utils/executeAgentChain.ts
@@ -158,6 +158,11 @@ export async function executeAgentChain(
           content: "",
           isFinal: false,
         })
+        // Give the browser a moment to render the placeholder so that
+        // subsequent chunks can visibly stream in. Without this small
+        // pause, the first agent's output could be buffered and rendered
+        // only after completion.
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
         const output = await callModel(
           `${basePrompt}\n\n${input}`,
           agent.model,


### PR DESCRIPTION
## Summary
- add a requestAnimationFrame delay after creating placeholder for each agent so the browser can render it before streaming begins

## Testing
- `npm run lint` *(fails: 111 errors, 20 warnings from existing files)*
- `npx eslint src/utils/executeAgentChain.ts`

------
https://chatgpt.com/codex/tasks/task_e_6891e748e5ac8333ad8303113ff927e3