### PR TITLE
Ensure agent chain streaming starts with first agent

### DIFF
--- a/src/utils/executeAgentChain.ts
+++ b/src/utils/executeAgentChain.ts
@@ -162,7 +162,7 @@ export async function executeAgentChain(
         // subsequent chunks can visibly stream in. Without this small
         // pause, the first agent's output could be buffered and rendered
         // only after completion.
-        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+        await new Promise(resolve => setTimeout(resolve, 0))
         const output = await callModel(
           `${basePrompt}\n\n${input}`,
           agent.model,


### PR DESCRIPTION
## Summary
- use a setTimeout-based delay so the UI can render the placeholder and show streaming from the first agent

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 131 problems (111 errors, 20 warnings))

------
https://chatgpt.com/codex/tasks/task_e_6891edbceda4833393571e54dc917324