### PR TITLE
feat: visualize agent chain pipeline

### DIFF
--- a/src/components/market/AgentChainVisualizer.tsx
+++ b/src/components/market/AgentChainVisualizer.tsx
@@ -1,0 +1,62 @@
+import { ArrowRight } from 'lucide-react'
+import { ChainConfig, Agent } from '@/utils/executeAgentChain'
+
+interface AgentChainVisualizerProps {
+  chain: ChainConfig
+  agents: Agent[]
+}
+
+// Helper to get truncated agent label
+function getAgentLabel(agentId: string, agents: Agent[]) {
+  const agent = agents.find(a => a.id === agentId)
+  if (!agent) return 'Unknown'
+  const prompt = agent.prompt || ''
+  return prompt.length > 20 ? `${prompt.slice(0, 20)}...` : prompt
+}
+
+export default function AgentChainVisualizer({ chain, agents }: AgentChainVisualizerProps) {
+  if (!chain || !chain.layers?.length) return null
+
+  return (
+    <div className="mt-4 space-y-6">
+      {chain.layers.map((layer, layerIdx) => (
+        <div key={layerIdx} className="flex items-start gap-4">
+          {/* Layer indicator */}
+          <div className="flex flex-col items-center">
+            <div className="flex items-center justify-center w-8 h-8 rounded-full bg-primary text-primary-foreground text-sm font-medium">
+              {layerIdx + 1}
+            </div>
+            {layerIdx < chain.layers.length - 1 && (
+              <div className="w-px flex-1 bg-muted" />
+            )}
+          </div>
+
+          {/* Agents within layer */}
+          <div className="flex-1">
+            <div className="flex flex-wrap items-center gap-3">
+              {layer.agents.map((block, idx) => (
+                <div key={idx} className="relative p-2 rounded-md bg-secondary text-secondary-foreground text-xs border">
+                  <div className="font-medium">
+                    {getAgentLabel(block.agentId, agents)}
+                  </div>
+                  {block.copies && block.copies > 1 && (
+                    <div className="text-[10px] text-muted-foreground">×{block.copies}</div>
+                  )}
+                  {block.routes && block.routes.length > 0 && (
+                    <div className="mt-1 text-[10px] text-muted-foreground flex items-center">
+                      <ArrowRight className="w-3 h-3 mr-1" />
+                      {block.routes
+                        .map(r => `L${layerIdx + 2}A${r + 1}`)
+                        .join(', ')}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+

--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Textarea } from "@/components/ui/textarea"
 import AgentChainDialog from './AgentChainDialog'
+import AgentChainVisualizer from './AgentChainVisualizer'
 import { executeAgentChain, ChainConfig, AgentOutput } from "@/utils/executeAgentChain"
 
 interface MarketChatboxProps {
@@ -151,21 +152,7 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
     }
   }
 
-  const renderChainSummary = () => {
-    const chain = chains.find(c => c.id === selectedChain)
-    if (!chain) return null
-    const getAgentLabel = (id: string) => agents.find(a => a.id === id)?.prompt.slice(0, 20) || 'Unknown'
-    return (
-      <div className="mt-2 text-xs text-muted-foreground space-y-1">
-        {chain.config.layers.map((layer, idx) => (
-          <div key={idx}>
-            <span className="font-medium">Layer {idx + 1}:</span>{' '}
-            {layer.agents.map(a => getAgentLabel(a.agentId)).join(', ')}
-          </div>
-        ))}
-      </div>
-    )
-  }
+  const selectedChainObj = chains.find(c => c.id === selectedChain)
 
   const saveAgent = async () => {
     if (!newAgentPrompt.trim() || !user?.id) return
@@ -406,7 +393,9 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
             </button>
           )}
         </div>
-        {selectedChain && renderChainSummary()}
+        {selectedChainObj && (
+          <AgentChainVisualizer chain={selectedChainObj.config} agents={agents} />
+        )}
       </div>
 
       {/* Model Selection */}


### PR DESCRIPTION
## Summary
- add AgentChainVisualizer component to render agent chain layers and routes
- integrate chain visualizer below chain selector in MarketChatbox

## Testing
- `npm run lint` *(fails: /workspace/market-movers-hub/supabase/functions/search-markets/index.ts 53:9 error 'allMarkets' is never reassigned. Use 'const' instead prefer-const)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689305c493208333bd18b868cb315cd7