### PR TITLE
Show only active layer agents in chat UI

### DIFF
--- a/src/utils/executeAgentChain.ts
+++ b/src/utils/executeAgentChain.ts
@@ -25,6 +25,11 @@ export interface AgentOutput {
   output: string
 }
 
+export interface AgentStart {
+  layer: number
+  agentId: string
+}
+
 interface ExecutionContext {
   userId?: string
   marketId: string
@@ -79,7 +84,8 @@ export async function executeAgentChain(
   agents: Agent[],
   initialInput: string,
   context: ExecutionContext,
-  onAgentOutput?: (output: AgentOutput) => void
+  onAgentOutput?: (output: AgentOutput) => void,
+  onAgentStart?: (info: AgentStart) => void
 ): Promise<{ prompt: string; model: string; outputs: AgentOutput[] }> {
   console.log('🚀 [executeAgentChain] Starting chain execution')
   console.log('🚀 [executeAgentChain] Chain config:', JSON.stringify(chainConfig, null, 2))
@@ -113,6 +119,7 @@ export async function executeAgentChain(
       console.log('🤖 [executeAgentChain] Routes:', block.routes)
 
       for (let c = 0; c < (block.copies || 1); c++) {
+        onAgentStart?.({ layer: i, agentId: agent.id })
         console.log(`📡 [executeAgentChain] Calling model for agent ${agent.id}, copy ${c + 1}`)
         const output = await callModel(
           `${basePrompt}\n\n${input}`,
@@ -159,6 +166,7 @@ export async function executeAgentChain(
       console.log('🤖 [executeAgentChain] Input:', input)
 
       for (let c = 0; c < (block.copies || 1); c++) {
+        onAgentStart?.({ layer: chainConfig.layers.length - 1, agentId: agent.id })
         console.log(`📡 [executeAgentChain] Calling model for agent ${agent.id}, copy ${c + 1}`)
         const output = await callModel(
           `${basePrompt}\n\n${input}`,


### PR DESCRIPTION
## Summary
- add `onAgentStart` callback so chains signal when each agent begins
- show agent placeholders only for current layer and color-code bubbles with spinner icons

## Testing
- `npm run lint` *(fails: allMarkets is never reassigned, resultsUrl is never reassigned, etc.)*
- `npx eslint src/components/market/MarketChatbox.tsx src/utils/executeAgentChain.ts && echo 'eslint: no problems found'`


------
https://chatgpt.com/codex/tasks/task_e_6893103bdc488333bc7e31718467e6e3