### PR TITLE
feat: add json mode for agents

### DIFF
--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -8,6 +8,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Textarea } from "@/components/ui/textarea"
+import { Input } from "@/components/ui/input"
+import { Switch } from "@/components/ui/switch"
+import { Label } from "@/components/ui/label"
 import AgentChainDialog from './AgentChainDialog'
 import AgentChainVisualizer from './AgentChainVisualizer'
 import { executeAgentChain, ChainConfig, AgentOutput } from "@/utils/executeAgentChain"
@@ -31,12 +34,18 @@ interface OpenRouterModel {
   id: string
   name: string
   description?: string
+  supports_response_format?: boolean
 }
 
 interface Agent {
   id: string
   prompt: string
   model: string
+  json_mode?: boolean
+  json_schema?: {
+    name: string
+    schema: any
+  }
 }
 
 interface AgentChain {
@@ -60,6 +69,9 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
   const [editingChain, setEditingChain] = useState<AgentChain | null>(null)
   const [newAgentPrompt, setNewAgentPrompt] = useState('')
   const [newAgentModel, setNewAgentModel] = useState('perplexity/sonar')
+  const [newAgentJsonMode, setNewAgentJsonMode] = useState(false)
+  const [newAgentJsonSchemaName, setNewAgentJsonSchemaName] = useState('')
+  const [newAgentJsonSchemaBody, setNewAgentJsonSchemaBody] = useState('')
   const [chains, setChains] = useState<AgentChain[]>([])
   const [selectedChain, setSelectedChain] = useState('')
   const { user } = useCurrentUser()
@@ -87,9 +99,9 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
         console.error('Failed to fetch OpenRouter models:', error)
         // Set fallback models if API fails
         setAvailableModels([
-          { id: 'perplexity/sonar', name: 'Perplexity Sonar', description: 'Fast and accurate' },
-          { id: 'openai/gpt-4o-mini', name: 'GPT-4o Mini', description: 'OpenAI fast model' },
-          { id: 'anthropic/claude-3-haiku', name: 'Claude 3 Haiku', description: 'Anthropic fast model' }
+          { id: 'perplexity/sonar', name: 'Perplexity Sonar', description: 'Fast and accurate', supports_response_format: false },
+          { id: 'openai/gpt-4o-mini', name: 'GPT-4o Mini', description: 'OpenAI fast model', supports_response_format: true },
+          { id: 'anthropic/claude-3-haiku', name: 'Claude 3 Haiku', description: 'Anthropic fast model', supports_response_format: false }
         ])
       } finally {
         setModelsLoading(false)
@@ -104,7 +116,7 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
       if (!user?.id) return
       const { data, error } = await supabase
         .from('agents')
-        .select('id, prompt, model')
+        .select('id, prompt, model, json_mode, json_schema')
         .eq('user_id', user.id)
         .order('created_at', { ascending: false })
 
@@ -142,7 +154,7 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
     if (agent) {
       setSelectedAgent(agentId)
       setSelectedModel(agent.model)
-      handleChatMessage(agent.prompt)
+      handleChatMessage(agent.prompt, undefined, agent.id)
     }
   }
 
@@ -159,12 +171,48 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
   }
 
   const selectedChainObj = chains.find(c => c.id === selectedChain)
+  const selectedAgentObj = agents.find(a => a.id === selectedAgent)
+
+  useEffect(() => {
+    if (selectedAgentObj?.json_mode) {
+      const jsonModels = availableModels.filter(m => m.supports_response_format)
+      if (!jsonModels.some(m => m.id === selectedModel)) {
+        setSelectedModel(jsonModels[0]?.id || '')
+      }
+    }
+  }, [selectedAgentObj, availableModels])
+
+  useEffect(() => {
+    const models = newAgentJsonMode
+      ? availableModels.filter(m => m.supports_response_format)
+      : availableModels
+    if (!models.some(m => m.id === newAgentModel)) {
+      setNewAgentModel(models[0]?.id || '')
+    }
+  }, [newAgentJsonMode, availableModels])
 
   const saveAgent = async () => {
     if (!newAgentPrompt.trim() || !user?.id) return
+    let schemaObj = null
+    if (newAgentJsonMode && newAgentJsonSchemaBody.trim()) {
+      try {
+        schemaObj = {
+          name: newAgentJsonSchemaName || 'schema',
+          schema: JSON.parse(newAgentJsonSchemaBody)
+        }
+      } catch (e) {
+        console.error('Invalid JSON schema:', e)
+      }
+    }
     const { data, error } = await supabase
       .from('agents')
-      .insert({ user_id: user.id, prompt: newAgentPrompt, model: newAgentModel })
+      .insert({
+        user_id: user.id,
+        prompt: newAgentPrompt,
+        model: newAgentModel,
+        json_mode: newAgentJsonMode,
+        json_schema: schemaObj
+      })
       .select()
       .single()
     if (error) {
@@ -175,15 +223,18 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
       setAgents(prev => [data, ...prev])
       setSelectedAgent(data.id)
       setSelectedModel(data.model)
-      handleChatMessage(data.prompt)
+      handleChatMessage(data.prompt, undefined, data.id)
     }
     setIsAgentDialogOpen(false)
     setNewAgentPrompt('')
     setNewAgentModel(selectedModel)
+    setNewAgentJsonMode(false)
+    setNewAgentJsonSchemaName('')
+    setNewAgentJsonSchemaBody('')
   }
 
   // Chat functionality using Web Worker
-  const handleChatMessage = async (userMessage: string, chainId?: string) => {
+  const handleChatMessage = async (userMessage: string, chainId?: string, agentId?: string) => {
     const activeChainId = chainId
     if ((!userMessage.trim() && !activeChainId) || isLoading) return
 
@@ -206,8 +257,10 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
 
       let finalPrompt = userMessage
       let finalModel = selectedModel
-      let finalAgentId: string | undefined
+      let finalAgentId: string | undefined = agentId
       let finalLayerIndex: number | undefined
+      let finalJsonMode: boolean | undefined
+      let finalJsonSchema: any
 
       const handleAgentOutput = (output: AgentOutput) => {
         setMessages(prev => {
@@ -257,6 +310,8 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
         )
         finalPrompt = result.prompt
         finalModel = result.model
+        finalJsonMode = result.json_mode
+        finalJsonSchema = result.json_schema
       }
 
       const baseHistory = messages
@@ -279,6 +334,12 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
       }
       setMessages(prev => [...prev, finalPlaceholder])
 
+      if (!finalJsonMode && finalAgentId) {
+        const agent = agents.find(a => a.id === finalAgentId)
+        finalJsonMode = agent?.json_mode
+        finalJsonSchema = agent?.json_schema
+      }
+
       const { data, error } = await supabase.functions.invoke('market-chat', {
         body: {
           message: finalPrompt,
@@ -287,7 +348,9 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
           marketId,
           marketQuestion,
           marketDescription,
-          selectedModel: finalModel
+          selectedModel: finalModel,
+          jsonMode: finalJsonMode,
+          jsonSchema: finalJsonSchema
         }
       })
 
@@ -461,7 +524,10 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
             <SelectValue placeholder={modelsLoading ? "Loading..." : "Select model"} />
           </SelectTrigger>
           <SelectContent>
-            {availableModels.map((model) => (
+            {(selectedAgentObj?.json_mode
+              ? availableModels.filter(m => m.supports_response_format)
+              : availableModels
+            ).map((model) => (
               <SelectItem key={model.id} value={model.id} className="text-xs">
                 <div>
                   <div className="font-medium">{model.name}</div>
@@ -520,6 +586,35 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
               placeholder="Enter agent prompt"
               className="h-24"
             />
+            <div className="flex items-center space-x-2">
+              <Switch
+                id="json-mode"
+                checked={newAgentJsonMode}
+                onCheckedChange={(checked) => {
+                  setNewAgentJsonMode(checked)
+                  if (!checked) {
+                    setNewAgentJsonSchemaName('')
+                    setNewAgentJsonSchemaBody('')
+                  }
+                }}
+              />
+              <Label htmlFor="json-mode" className="text-sm">Enable JSON mode</Label>
+            </div>
+            {newAgentJsonMode && (
+              <div className="space-y-2">
+                <Input
+                  value={newAgentJsonSchemaName}
+                  onChange={(e) => setNewAgentJsonSchemaName(e.target.value)}
+                  placeholder="Schema name"
+                />
+                <Textarea
+                  value={newAgentJsonSchemaBody}
+                  onChange={(e) => setNewAgentJsonSchemaBody(e.target.value)}
+                  placeholder='{"type":"object","properties":{},"required":[]}'
+                  className="h-24 font-mono"
+                />
+              </div>
+            )}
             <div className="space-y-2">
               <span className="text-sm text-muted-foreground">Model:</span>
               <Select value={newAgentModel} onValueChange={setNewAgentModel} disabled={modelsLoading}>
@@ -527,7 +622,7 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
                   <SelectValue placeholder={modelsLoading ? 'Loading...' : 'Select model'} />
                 </SelectTrigger>
                 <SelectContent>
-                  {availableModels.map((model) => (
+                  {(newAgentJsonMode ? availableModels.filter(m => m.supports_response_format) : availableModels).map((model) => (
                     <SelectItem key={model.id} value={model.id} className="text-xs">
                       <div>
                         <div className="font-medium">{model.name}</div>

--- a/src/utils/executeAgentChain.ts
+++ b/src/utils/executeAgentChain.ts
@@ -2,6 +2,8 @@ export interface Agent {
   id: string
   prompt: string
   model: string
+  json_mode?: boolean
+  json_schema?: unknown
 }
 
 interface AgentBlock {
@@ -41,7 +43,9 @@ interface ExecutionContext {
 async function callModel(
   prompt: string,
   model: string,
-  context: ExecutionContext
+  context: ExecutionContext,
+  json_mode?: boolean,
+  json_schema?: unknown
 ): Promise<string> {
   console.log('🧠 [callModel] Invoking model', model)
   console.log('🧠 [callModel] Prompt:', prompt)
@@ -63,6 +67,8 @@ async function callModel(
         marketQuestion: context.marketQuestion,
         marketDescription: context.marketDescription,
         selectedModel: model,
+        jsonMode: json_mode,
+        jsonSchema: json_schema,
       }),
     }
   )
@@ -124,7 +130,9 @@ export async function executeAgentChain(
         const output = await callModel(
           `${basePrompt}\n\n${input}`,
           agent.model,
-          context
+          context,
+          agent.json_mode,
+          agent.json_schema
         )
         console.log(`📦 [executeAgentChain] Output from agent ${agent.id}:`, output)
         const agentOutput = { layer: i, agentId: agent.id, output }
@@ -171,7 +179,9 @@ export async function executeAgentChain(
         const output = await callModel(
           `${basePrompt}\n\n${input}`,
           agent.model,
-          context
+          context,
+          agent.json_mode,
+          agent.json_schema
         )
         console.log(`📦 [executeAgentChain] Output from agent ${agent.id}:`, output)
         const agentOutput = {
@@ -201,6 +211,8 @@ export async function executeAgentChain(
   return {
     prompt: `${finalPromptBase}\n\n${finalInput}`.trim(),
     model: finalAgent.model,
+    json_mode: finalAgent.json_mode,
+    json_schema: finalAgent.json_schema,
     outputs: agentOutputs,
   }
 }

--- a/supabase/functions/get-openrouter-models/index.ts
+++ b/supabase/functions/get-openrouter-models/index.ts
@@ -109,7 +109,8 @@ serve(async (req) => {
         const isDalle = model.id.includes('dall-e') || model.name.toLowerCase().includes('dall-e')
         
         return !isEmbedding && !isWhisper && !isDalle
-      })
+  })
+
       .sort((a, b) => {
         // Prioritize popular models at the top
         const priorityModels = [
@@ -141,16 +142,20 @@ serve(async (req) => {
     console.log('Filtered chat models:', chatModels.length)
 
     return new Response(
-      JSON.stringify({ 
+      JSON.stringify({
         models: chatModels.map(model => ({
           id: model.id,
           name: model.name,
           description: model.description,
           context_length: model.context_length,
-          pricing: model.pricing
+          pricing: model.pricing,
+          supports_response_format: Array.isArray(model.supported_parameters)
+            ? model.supported_parameters.includes('response_format') ||
+              model.supported_parameters.includes('structured_outputs')
+            : false
         }))
       }),
-      { 
+      {
         headers: {
           ...corsHeaders,
           'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary
- allow creating agents with JSON mode and custom schema
- filter OpenRouter models to those supporting `response_format`
- send JSON schema info through agent chains and market chat

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 133 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68931f0e7d988333bd0b4815bcc66a52