### PR TITLE
Refine agent chain visualizer layout

### DIFF
--- a/src/components/market/AgentChainVisualizer.tsx
+++ b/src/components/market/AgentChainVisualizer.tsx
@@ -18,40 +18,46 @@ export default function AgentChainVisualizer({ chain, agents }: AgentChainVisual
   if (!chain || !chain.layers?.length) return null
 
   return (
-    <div className="mt-4 space-y-6">
+    <div className="mt-4 space-y-4 text-xs">
       {chain.layers.map((layer, layerIdx) => (
-        <div key={layerIdx} className="flex items-start gap-4">
+        <div key={layerIdx} className="flex items-stretch gap-3">
           {/* Layer indicator */}
-          <div className="flex flex-col items-center">
-            <div className="flex items-center justify-center w-8 h-8 rounded-full bg-primary text-primary-foreground text-sm font-medium">
+          <div className="flex flex-col items-center w-6">
+            <div className="flex items-center justify-center w-6 h-6 rounded-full bg-primary text-primary-foreground text-xs font-medium">
               {layerIdx + 1}
             </div>
             {layerIdx < chain.layers.length - 1 && (
-              <div className="w-px flex-1 bg-muted" />
+              <div className="w-px flex-1 bg-border" />
             )}
           </div>
 
           {/* Agents within layer */}
           <div className="flex-1">
-            <div className="flex flex-wrap items-center gap-3">
-              {layer.agents.map((block, idx) => (
-                <div key={idx} className="relative p-2 rounded-md bg-secondary text-secondary-foreground text-xs border">
-                  <div className="font-medium">
-                    {getAgentLabel(block.agentId, agents)}
-                  </div>
-                  {block.copies && block.copies > 1 && (
-                    <div className="text-[10px] text-muted-foreground">×{block.copies}</div>
-                  )}
-                  {block.routes && block.routes.length > 0 && (
-                    <div className="mt-1 text-[10px] text-muted-foreground flex items-center">
-                      <ArrowRight className="w-3 h-3 mr-1" />
-                      {block.routes
-                        .map(r => `L${layerIdx + 2}A${r + 1}`)
-                        .join(', ')}
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+              {layer.agents.map((block, idx) => {
+                const agent = agents.find(a => a.id === block.agentId)
+                const label = getAgentLabel(block.agentId, agents)
+                return (
+                  <div key={idx} className="p-2 rounded-md border bg-card text-card-foreground">
+                    <div className="font-medium truncate" title={agent?.prompt || ''}>
+                      {label}
                     </div>
-                  )}
-                </div>
-              ))}
+                    {block.copies && block.copies > 1 && (
+                      <div className="text-[10px] text-muted-foreground">×{block.copies}</div>
+                    )}
+                    {block.routes && block.routes.length > 0 && (
+                      <div className="mt-1 flex flex-wrap items-center gap-1 text-[10px] text-muted-foreground">
+                        <ArrowRight className="w-3 h-3" />
+                        {block.routes.map(r => (
+                          <span key={r} className="px-1 py-0.5 rounded bg-muted">
+                            {`L${layerIdx + 2}A${r + 1}`}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- streamline the agent chain visualizer with a compact, responsive grid layout
- add truncation and tooltips for long agent prompts
- modernize route display with badge-like labels and smaller spacing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 109 errors, 21 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689340697a4c8333b6e882cd0f29702a