### PR TITLE
feat: add external link for top movers

### DIFF
--- a/src/components/market/MarketCard.tsx
+++ b/src/components/market/MarketCard.tsx
@@ -13,6 +13,7 @@ interface Market {
   volume: number;
   total_volume: number;
   image: string;
+  url?: string;
   yes_sub_title?: string;
   final_last_traded_price: number;
   final_best_ask: number;
@@ -24,7 +25,7 @@ interface Market {
   event_id?: string;
   primary_tags?: string[];
   tag_slugs?: string[];
-  tags?: any[];
+  tags?: unknown[];
 }
 
 interface MarketCardProps {
@@ -69,6 +70,7 @@ export function MarketCard({
         primaryTags={market.primary_tags}
         tagSlugs={market.tag_slugs}
         tags={market.tags}
+        url={market.url}
       />
       <MarketStats
         lastTradedPrice={market.final_last_traded_price}

--- a/src/components/market/MarketHeader.tsx
+++ b/src/components/market/MarketHeader.tsx
@@ -2,10 +2,12 @@
 import { HoverButton } from "@/components/ui/hover-button";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { MarketTags } from "./MarketTags";
+import { ExternalLink } from "lucide-react";
 
 interface MarketHeaderProps {
   image: string;
   question: string;
+  url?: string;
   yesSubTitle?: string;
   bestBid?: number;
   bestAsk?: number;
@@ -16,17 +18,18 @@ interface MarketHeaderProps {
   onToggleExpand: () => void;
   primaryTags?: string[];
   tagSlugs?: string[];
-  tags?: any[];
+  tags?: unknown[];
 }
 
-export function MarketHeader({ 
-  image, 
-  question, 
-  yesSubTitle, 
+export function MarketHeader({
+  image,
+  question,
+  url,
+  yesSubTitle,
   bestBid,
   bestAsk,
-  noPrice,  
-  onBuy, 
+  noPrice,
+  onBuy,
   onSell,
   outcomes = ["Yes", "No"],
   onToggleExpand,
@@ -48,23 +51,38 @@ export function MarketHeader({
           alt=""
           className={`${isMobile ? 'w-9 h-9' : 'w-12 h-12'} rounded-lg object-cover flex-shrink-0`}
         />
-        <div 
-          className="flex-1 min-w-0 cursor-pointer hover:opacity-80 transition-opacity py-1"
-          onClick={onToggleExpand}
-        >
-          <h3 className={`font-medium ${isMobile ? 'text-sm' : 'text-base'} leading-tight line-clamp-2`}>
-            {question}
-          </h3>
-          {yesSubTitle && (
-            <p className="text-xs text-muted-foreground mt-0.5 truncate">
-              {yesSubTitle}
-            </p>
-          )}
+        <div className="flex-1 min-w-0 py-1">
+          <div className="flex items-start gap-2">
+            <div
+              className="flex-1 min-w-0 cursor-pointer hover:opacity-80 transition-opacity"
+              onClick={onToggleExpand}
+            >
+              <h3 className={`font-medium ${isMobile ? 'text-sm' : 'text-base'} leading-tight line-clamp-2`}>
+                {question}
+              </h3>
+              {yesSubTitle && (
+                <p className="text-xs text-muted-foreground mt-0.5 truncate">
+                  {yesSubTitle}
+                </p>
+              )}
+            </div>
+            {url && (
+              <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => e.stopPropagation()}
+                className="mt-1 flex-shrink-0 text-muted-foreground hover:text-foreground"
+              >
+                <ExternalLink className={isMobile ? 'w-4 h-4' : 'w-5 h-5'} />
+              </a>
+            )}
+          </div>
           <div className="mt-1">
-            <MarketTags 
-              primaryTags={primaryTags} 
-              tagSlugs={tagSlugs} 
-              tags={tags} 
+            <MarketTags
+              primaryTags={primaryTags}
+              tagSlugs={tagSlugs}
+              tags={tags}
               maxTags={isMobile ? 2 : 3}
             />
           </div>

--- a/src/components/market/TopMoversContent.tsx
+++ b/src/components/market/TopMoversContent.tsx
@@ -79,6 +79,7 @@ export function TopMoversContent({
                 volume: mover.volume_change,
                 total_volume: mover.final_volume,
                 image: mover.image || '/placeholder.svg',
+                url: mover.url,
                 yes_sub_title: mover.yes_sub_title,
                 final_last_traded_price: mover.final_last_price,
                 final_best_ask: mover.final_best_ask,


### PR DESCRIPTION
## Summary
- show external link for each top mover, forwarding URL through MarketCard and MarketHeader

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 109 errors, 21 warnings)
- `npx eslint src/components/market/MarketCard.tsx src/components/market/MarketHeader.tsx src/components/market/TopMoversContent.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68935a7827ac833396f8d99106acb47a