### PR TITLE
feat: support field routing for json agents

### DIFF
--- a/src/components/market/AgentChainVisualizer.tsx
+++ b/src/components/market/AgentChainVisualizer.tsx
@@ -47,9 +47,11 @@ export default function AgentChainVisualizer({ chain, agents }: AgentChainVisual
                           const targetLabel = targetBlock
                             ? getAgentLabel(targetBlock.agentId, agents)
                             : `Layer ${layerIdx + 2} Agent ${r + 1}`
+                          const fields = block.fieldRoutes?.[r]
                           return (
                             <span key={r} className="px-1 py-0.5 rounded bg-muted">
                               {targetLabel}
+                              {fields && fields.length > 0 && ` (${fields.join(', ')})`}
                             </span>
                           )
                         })}


### PR DESCRIPTION
## Summary
- allow agent chain builder to select fields from JSON-mode agents when routing
- pass selected fields through chain execution and show them in visualizer

## Testing
- `npm run lint` (fails: 130 problems, e.g. supabase/functions/...)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893e39275448333936daf71b8625d33