### PR TITLE
fix: show JSON schema fields in agent chain routing

### DIFF
--- a/src/components/market/AgentChainDialog.tsx
+++ b/src/components/market/AgentChainDialog.tsx
@@ -259,8 +259,14 @@ export function AgentChainDialog({ open, onOpenChange, agents, onSaved, chain }:
                     let schemaFields: string[] = []
                     if (agentObj?.json_mode && agentObj.json_schema) {
                       try {
-                        const schema = typeof agentObj.json_schema === 'string' ? JSON.parse(agentObj.json_schema) : agentObj.json_schema
-                        schemaFields = Object.keys(schema?.properties || {})
+                        const schema =
+                          typeof agentObj.json_schema === 'string'
+                            ? JSON.parse(agentObj.json_schema)
+                            : agentObj.json_schema
+                        schemaFields = Object.keys(
+                          // json_schema follows the structure { schema: { properties: { ... } } }
+                          (schema as { schema?: { properties?: Record<string, unknown> } })?.schema?.properties || {}
+                        )
                       } catch {
                         schemaFields = []
                       }


### PR DESCRIPTION
## Summary
- parse agent `json_schema` from the correct `schema.properties` path
- display field routing options when selecting JSON-mode agents

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893e8afcf448333b34a3fa136fcf6ea