### PR TITLE
feat: show JSON output fields in chain modal

### DIFF
--- a/src/components/market/AgentChainDialog.tsx
+++ b/src/components/market/AgentChainDialog.tsx
@@ -265,12 +265,18 @@ export function AgentChainDialog({ open, onOpenChange, agents, onSaved, chain }:
                       onChange={(e) => updateAgentBlock(layerIndex, agentIndex, 'prompt', e.target.value)}
                     />
                     {schemaFields.length > 0 && (
-                      <div className="flex flex-wrap gap-1 text-xs text-muted-foreground">
-                        {schemaFields.map(field => (
-                          <span key={field} className="rounded bg-muted px-1 py-0.5">
-                            {field}
-                          </span>
-                        ))}
+                      <div className="text-xs space-y-1">
+                        <div className="text-muted-foreground font-medium">JSON Output</div>
+                        <div className="flex flex-wrap gap-1">
+                          {schemaFields.map(field => (
+                            <span
+                              key={field}
+                              className="rounded bg-muted px-1 py-0.5 text-foreground"
+                            >
+                              {field}
+                            </span>
+                          ))}
+                        </div>
                       </div>
                     )}
                   </div>


### PR DESCRIPTION
## Summary
- label and display JSON output fields immediately when selecting JSON-mode agents
- improve contrast of JSON field tags

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 107 errors, 21 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6893edfa7a608333946942795e9cf4d9