### PR TITLE
feat: require send to run selected agent

### DIFF
--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -176,7 +176,7 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
     if (agent) {
       setSelectedAgent(agentId)
       setSelectedModel(agent.model)
-      handleChatMessage(agent.prompt, undefined, agent.id)
+      setChatMessage(agent.prompt)
     }
   }
 
@@ -287,7 +287,7 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
         updatedAgents = agents.map(a => (a.id === data.id ? data : a))
       } else {
         updatedAgents = [data, ...agents]
-        handleChatMessage(data.prompt, undefined, data.id, updatedAgents)
+        setChatMessage(data.prompt)
       }
       setAgents(updatedAgents)
       setSelectedAgent(data.id)


### PR DESCRIPTION
## Summary
- prevent MarketChatbox from auto-executing an agent when selected, instead pre-fill the chat input
- avoid running a newly saved agent automatically; pre-fill its prompt for manual submission

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 128 problems (107 errors, 21 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_6894087f5ed08333b85cbddbe3ea0664