### PR TITLE
Display agent input previews in chain messages

### DIFF
--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -30,6 +30,7 @@ interface Message {
   layer?: number
   isTyping?: boolean
   jsonMode?: boolean
+  input?: string
 }
 
 interface OpenRouterModel {
@@ -352,9 +353,12 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
         })
       }
 
-      const handleAgentStart = ({ layer, agentId }: { layer: number; agentId: string }) => {
+      const handleAgentStart = ({ layer, agentId, input }: { layer: number; agentId: string; input?: string }) => {
         const agent = currentAgents.find(a => a.id === agentId)
-        setMessages(prev => [...prev, { type: 'assistant', agentId, layer, isTyping: true, jsonMode: agent?.json_mode }])
+        setMessages(prev => [
+          ...prev,
+          { type: 'assistant', agentId, layer, isTyping: true, jsonMode: agent?.json_mode, input }
+        ])
       }
 
       if (activeChainId) {
@@ -408,7 +412,8 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
         agentId: finalAgentId,
         layer: finalLayerIndex,
         isTyping: true,
-        jsonMode: finalJsonMode
+        jsonMode: finalJsonMode,
+        input: finalPrompt
       }
       setMessages(prev => [...prev, finalPlaceholder])
 
@@ -511,6 +516,14 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
                       <p className={`text-xs font-medium mb-1 flex items-center ${style.text}`}>
                         <GitBranch className="w-3 h-3 mr-1" />
                         Layer {message.layer + 1} · Agent {message.agentId}
+                      </p>
+                    )}
+                    {message.input && (
+                      <p
+                        className="text-[10px] text-muted-foreground mb-1 truncate cursor-help"
+                        title={message.input}
+                      >
+                        {message.input.length > 100 ? `${message.input.slice(0, 100)}...` : message.input}
                       </p>
                     )}
                     {message.isTyping ? (

--- a/src/utils/executeAgentChain.ts
+++ b/src/utils/executeAgentChain.ts
@@ -33,6 +33,7 @@ export interface AgentOutput {
 export interface AgentStart {
   layer: number
   agentId: string
+  input?: string
 }
 
 interface ExecutionContext {
@@ -163,7 +164,7 @@ export async function executeAgentChain(
       console.log('🤖 [executeAgentChain] Routes:', block.routes)
 
       for (let c = 0; c < (block.copies || 1); c++) {
-        onAgentStart?.({ layer: i, agentId: agent.id })
+        onAgentStart?.({ layer: i, agentId: agent.id, input })
         console.log(`📡 [executeAgentChain] Calling model for agent ${agent.id}, copy ${c + 1}`)
         const output = await callModel(
           fullPrompt,
@@ -248,7 +249,7 @@ export async function executeAgentChain(
       console.log('📜 [executeAgentChain] Full prompt:', fullPrompt)
 
       for (let c = 0; c < (block.copies || 1); c++) {
-        onAgentStart?.({ layer: chainConfig.layers.length - 1, agentId: agent.id })
+        onAgentStart?.({ layer: chainConfig.layers.length - 1, agentId: agent.id, input })
         console.log(`📡 [executeAgentChain] Calling model for agent ${agent.id}, copy ${c + 1}`)
         const output = await callModel(
           fullPrompt,


### PR DESCRIPTION
## Summary
- pass agent input text through chain execution callbacks
- show truncated agent input with hover tooltip in market chat messages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 126 problems)

------
https://chatgpt.com/codex/tasks/task_e_689419415bf883339007fa68d6ef9774