### PR TITLE
feat: allow custom agent prompts

### DIFF
--- a/supabase/migrations/20250915000000_add_agent_system_prompt.sql
+++ b/supabase/migrations/20250915000000_add_agent_system_prompt.sql
@@ -1,0 +1,3 @@
+-- Add column for storing custom agent system prompts
+ALTER TABLE profiles
+ADD COLUMN agent_system_prompt text;


### PR DESCRIPTION
## Summary
- allow market chat to append user-provided agent instructions
- expose custom agent prompt in account settings and persist to Supabase
- add migration for agent_system_prompt field

## Testing
- `npm run lint` *(fails: allMarkets is never reassigned; resultsUrl is never reassigned; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68942262ca3c8333a7390fbae5380bfe