### PR TITLE
feat: allow custom system prompts for agents

### DIFF
--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -44,6 +44,7 @@ interface Agent {
   id: string
   prompt: string
   model: string
+  system_prompt?: string
   json_mode?: boolean
   json_schema?: unknown
 }
@@ -72,6 +73,7 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
   const [newAgentModel, setNewAgentModel] = useState('perplexity/sonar')
   const [newAgentJsonMode, setNewAgentJsonMode] = useState(false)
   const [newAgentJsonSchema, setNewAgentJsonSchema] = useState('')
+  const [newAgentSystemPrompt, setNewAgentSystemPrompt] = useState('')
   const [chains, setChains] = useState<AgentChain[]>([])
   const [selectedChain, setSelectedChain] = useState('')
   const { user } = useCurrentUser()
@@ -142,7 +144,7 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
       if (!user?.id) return
       const { data, error } = await supabase
         .from('agents')
-        .select('id, prompt, model, json_mode, json_schema')
+        .select('id, prompt, model, system_prompt, json_mode, json_schema')
         .eq('user_id', user.id)
         .order('created_at', { ascending: false })
 
@@ -229,6 +231,7 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
     setNewAgentModel(selectedModel)
     setNewAgentJsonMode(false)
     setNewAgentJsonSchema('')
+    setNewAgentSystemPrompt('')
     setIsAgentDialogOpen(true)
   }
 
@@ -241,6 +244,7 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
     setNewAgentModel(agent.model)
     setNewAgentJsonMode(!!agent.json_mode)
     setNewAgentJsonSchema(agent.json_schema ? JSON.stringify(agent.json_schema, null, 2) : '')
+    setNewAgentSystemPrompt(agent.system_prompt || '')
     setIsAgentDialogOpen(true)
   }
 
@@ -262,6 +266,7 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
         .update({
           prompt: newAgentPrompt,
           model: newAgentModel,
+          system_prompt: newAgentSystemPrompt,
           json_mode: newAgentJsonMode,
           json_schema: schemaObj
         })
@@ -275,6 +280,7 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
           user_id: user.id,
           prompt: newAgentPrompt,
           model: newAgentModel,
+          system_prompt: newAgentSystemPrompt,
           json_mode: newAgentJsonMode,
           json_schema: schemaObj
         })
@@ -303,6 +309,7 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
     setNewAgentModel(selectedModel)
     setNewAgentJsonMode(false)
     setNewAgentJsonSchema('')
+    setNewAgentSystemPrompt('')
   }
 
   // Chat functionality using Web Worker
@@ -436,7 +443,8 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
           marketDescription,
           selectedModel: finalModel,
           jsonMode: finalJsonMode,
-          jsonSchema: finalJsonSchema
+          jsonSchema: finalJsonSchema,
+          customSystemPrompt: currentAgents.find(a => a.id === finalAgentId)?.system_prompt
         }
       })
 
@@ -695,6 +703,12 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
           </DialogHeader>
           <ScrollArea className="max-h-[60vh] pr-4">
             <div className="space-y-4">
+              <Textarea
+                value={newAgentSystemPrompt}
+                onChange={(e) => setNewAgentSystemPrompt(e.target.value)}
+                placeholder="Enter system prompt (optional)"
+                className="h-24"
+              />
               <Textarea
                 value={newAgentPrompt}
                 onChange={(e) => setNewAgentPrompt(e.target.value)}

--- a/src/utils/executeAgentChain.ts
+++ b/src/utils/executeAgentChain.ts
@@ -4,6 +4,7 @@ export interface Agent {
   id: string
   prompt: string
   model: string
+  system_prompt?: string
   json_mode?: boolean
   json_schema?: unknown
 }
@@ -67,7 +68,8 @@ async function callModel(
   model: string,
   context: ExecutionContext,
   json_mode?: boolean,
-  json_schema?: unknown
+  json_schema?: unknown,
+  system_prompt?: string
 ): Promise<string> {
   console.log('🧠 [callModel] Invoking model', model)
   console.log('🧠 [callModel] Prompt:', prompt)
@@ -85,6 +87,7 @@ async function callModel(
         selectedModel: model,
         jsonMode: json_mode,
         jsonSchema: json_schema,
+        customSystemPrompt: system_prompt,
       },
       headers: {
         Authorization: `Bearer ${context.authToken}`,
@@ -171,7 +174,8 @@ export async function executeAgentChain(
           agent.model,
           context,
           agent.json_mode,
-          agent.json_schema
+          agent.json_schema,
+          agent.system_prompt
         )
         console.log(`📦 [executeAgentChain] Output from agent ${agent.id}:`, output)
         const agentOutput = { layer: i, agentId: agent.id, output }
@@ -251,13 +255,14 @@ export async function executeAgentChain(
       for (let c = 0; c < (block.copies || 1); c++) {
         onAgentStart?.({ layer: chainConfig.layers.length - 1, agentId: agent.id, input })
         console.log(`📡 [executeAgentChain] Calling model for agent ${agent.id}, copy ${c + 1}`)
-        const output = await callModel(
-          fullPrompt,
-          agent.model,
-          context,
-          agent.json_mode,
-          agent.json_schema
-        )
+      const output = await callModel(
+        fullPrompt,
+        agent.model,
+        context,
+        agent.json_mode,
+        agent.json_schema,
+        agent.system_prompt
+      )
         console.log(`📦 [executeAgentChain] Output from agent ${agent.id}:`, output)
         const agentOutput = {
           layer: chainConfig.layers.length - 1,

--- a/supabase/migrations/20250916000000_add_system_prompt_to_agents.sql
+++ b/supabase/migrations/20250916000000_add_system_prompt_to_agents.sql
@@ -1,0 +1,3 @@
+-- Add system prompt column to agents table
+ALTER TABLE agents
+ADD COLUMN system_prompt text;


### PR DESCRIPTION
## Summary
- support custom system prompts when executing agent chains
- save system prompt alongside agent prompts in UI and database

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 116 errors, 20 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689428b768ec8333abed24bbfa0fe609