### PR TITLE
feat: color field-only agent routes

### DIFF
--- a/src/components/market/AgentChainVisualizer.tsx
+++ b/src/components/market/AgentChainVisualizer.tsx
@@ -46,7 +46,7 @@ export default function AgentChainVisualizer({ chain, agents }: AgentChainVisual
         const targetColor = agentColors[`${layerIdx + 1}-${r}`]
         if (targetColor === undefined) return
         const fields = block.fieldRoutes?.[r] || []
-        if (fields.length === 0) {
+        if (fields.length === 0 || (block.routes && block.routes.length === 1)) {
           agentColors[`${layerIdx}-${agentIdx}`] = targetColor
         }
       })


### PR DESCRIPTION
## Summary
- ensure agent block colors propagate when routing specific JSON fields to a single agent

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 127 problems)

------
https://chatgpt.com/codex/tasks/task_e_689443a9b7348333b1a40cd6884501f5