### PR TITLE
fix: format json message content

### DIFF
--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -97,15 +97,35 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
       try {
         data = JSON.parse(content)
       } catch {
-        return <pre className="text-sm">{content}</pre>
+        return (
+          <Markdown
+            className="inline"
+            components={{
+              p: ({ children }) => <span className="whitespace-pre-wrap">{children}</span>,
+            }}
+          >
+            {content}
+          </Markdown>
+        )
       }
     }
     if (typeof data === 'object' && data !== null) {
       return Object.entries(data as Record<string, unknown>).map(([key, value]) => (
-        <p key={key}>
-          <span className="font-medium">{formatKey(key)}:</span>{' '}
-          {typeof value === 'object' ? JSON.stringify(value) : String(value)}
-        </p>
+        <div key={key} className="flex items-start gap-1">
+          <span className="font-medium">{formatKey(key)}:</span>
+          {typeof value === 'string' ? (
+            <Markdown
+              className="inline"
+              components={{
+                p: ({ children }) => <span className="whitespace-pre-wrap">{children}</span>,
+              }}
+            >
+              {value}
+            </Markdown>
+          ) : (
+            <pre className="whitespace-pre-wrap">{JSON.stringify(value, null, 2)}</pre>
+          )}
+        </div>
       ))
     }
     return null


### PR DESCRIPTION
## Summary
- render text in JSON-mode chat responses with Markdown
- pretty-print object and array values for readability

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: existing lint errors)
- `npx eslint src/components/market/MarketChatbox.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68944a904cb88333a6ff59e694d4904c