### PR TITLE
fix: increase max tokens for market chat

### DIFF
--- a/supabase/functions/market-chat/index.ts
+++ b/supabase/functions/market-chat/index.ts
@@ -196,6 +196,7 @@ In your first reply, surface the most relevant and up-to-date online sources, ci
     const historyMessages = Array.isArray(chatHistory) ? chatHistory : []
     const requestBody: Record<string, unknown> = {
       model: selectedModel || "perplexity/sonar",
+      max_tokens: 4000,
       messages: [
         {
           role: "system",


### PR DESCRIPTION
## Summary
- prevent truncated replies by allowing up to 4000 output tokens in market chat requests

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 127 problems (107 errors, 20 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68944d548c9483339d108ddf9cf53e0b