### PR TITLE
fix: track agent status by index

### DIFF
--- a/src/components/market/MarketChatbox.tsx
+++ b/src/components/market/MarketChatbox.tsx
@@ -432,23 +432,21 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
       const handleAgentOutput = (output: AgentOutput) => {
         const agent = currentAgents.find(a => a.id === output.agentId)
         const isJson = agent?.json_mode
-        const agentIdx = chain?.config.layers[output.layer].agents.findIndex(b => b.agentId === output.agentId)
-        if (agentIdx !== undefined && agentIdx !== -1) {
-          setAgentStatuses(prev => ({ ...prev, [`${output.layer}-${agentIdx}`]: 'done' }))
-          if (isJson) {
-            try {
-              const parsed = JSON.parse(output.output)
-              const block = chain!.config.layers[output.layer].agents[agentIdx]
-              Object.entries(block.fieldRoutes || {}).forEach(([tIdx, fields]) => {
-                fields.forEach(f => {
-                  if (parsed && Object.prototype.hasOwnProperty.call(parsed, f)) {
-                    setFieldStatuses(prev => ({ ...prev, [`${output.layer}-${agentIdx}-${tIdx}-${f}`]: 'done' }))
-                  }
-                })
+        const agentIdx = output.agentIndex
+        setAgentStatuses(prev => ({ ...prev, [`${output.layer}-${agentIdx}`]: 'done' }))
+        if (isJson) {
+          try {
+            const parsed = JSON.parse(output.output)
+            const block = chain!.config.layers[output.layer].agents[agentIdx]
+            Object.entries(block.fieldRoutes || {}).forEach(([tIdx, fields]) => {
+              fields.forEach(f => {
+                if (parsed && Object.prototype.hasOwnProperty.call(parsed, f)) {
+                  setFieldStatuses(prev => ({ ...prev, [`${output.layer}-${agentIdx}-${tIdx}-${f}`]: 'done' }))
+                }
               })
-            } catch {
-              // ignore JSON parse errors
-            }
+            })
+          } catch {
+            // ignore JSON parse errors
           }
         }
         setMessages(prev => {
@@ -464,12 +462,9 @@ export function MarketChatbox({ marketId, marketQuestion, marketDescription }: M
         })
       }
 
-      const handleAgentStart = ({ layer, agentId, input }: { layer: number; agentId: string; input?: string }) => {
+      const handleAgentStart = ({ layer, agentId, agentIndex, input }: { layer: number; agentId: string; agentIndex: number; input?: string }) => {
         const agent = currentAgents.find(a => a.id === agentId)
-        const agentIdx = chain?.config.layers[layer].agents.findIndex(b => b.agentId === agentId)
-        if (agentIdx !== undefined && agentIdx !== -1) {
-          setAgentStatuses(prev => ({ ...prev, [`${layer}-${agentIdx}`]: 'running' }))
-        }
+        setAgentStatuses(prev => ({ ...prev, [`${layer}-${agentIndex}`]: 'running' }))
         setMessages(prev => [
           ...prev,
           { type: 'assistant', agentId, layer, isTyping: true, jsonMode: agent?.json_mode, input }

--- a/src/utils/executeAgentChain.ts
+++ b/src/utils/executeAgentChain.ts
@@ -28,12 +28,14 @@ export interface ChainConfig {
 export interface AgentOutput {
   layer: number
   agentId: string
+  agentIndex: number
   output: string
 }
 
 export interface AgentStart {
   layer: number
   agentId: string
+  agentIndex: number
   input?: string
 }
 
@@ -177,7 +179,7 @@ export async function executeAgentChain(
       if (!agent) {
         const msg = `Agent ID ${block.agentId} not found`
         console.warn(`⚠️ [executeAgentChain] ${msg}`)
-        onAgentOutput?.({ layer: i, agentId: block.agentId, output: msg })
+        onAgentOutput?.({ layer: i, agentId: block.agentId, agentIndex, output: msg })
         continue
       }
 
@@ -195,7 +197,7 @@ export async function executeAgentChain(
       console.log('🤖 [executeAgentChain] Routes:', block.routes)
 
       for (let c = 0; c < (block.copies || 1); c++) {
-        onAgentStart?.({ layer: i, agentId: agent.id, input })
+        onAgentStart?.({ layer: i, agentId: agent.id, agentIndex, input })
         console.log(`📡 [executeAgentChain] Calling model for agent ${agent.id}, copy ${c + 1}`)
         const output = await callModel(
           fullPrompt,
@@ -206,7 +208,7 @@ export async function executeAgentChain(
           agent.system_prompt
         )
         console.log(`📦 [executeAgentChain] Output from agent ${agent.id}:`, output)
-        const agentOutput = { layer: i, agentId: agent.id, output }
+        const agentOutput = { layer: i, agentId: agent.id, agentIndex, output }
         agentOutputs.push(agentOutput)
         onAgentOutput?.(agentOutput)
 
@@ -268,7 +270,7 @@ export async function executeAgentChain(
       if (!agent) {
         const msg = `Agent ID ${block.agentId} not found`
         console.warn(`⚠️ [executeAgentChain] ${msg}`)
-        onAgentOutput?.({ layer: chainConfig.layers.length - 1, agentId: block.agentId, output: msg })
+        onAgentOutput?.({ layer: chainConfig.layers.length - 1, agentId: block.agentId, agentIndex, output: msg })
         continue
       }
 
@@ -285,7 +287,7 @@ export async function executeAgentChain(
       console.log('📜 [executeAgentChain] Full prompt:', fullPrompt)
 
       for (let c = 0; c < (block.copies || 1); c++) {
-        onAgentStart?.({ layer: chainConfig.layers.length - 1, agentId: agent.id, input })
+        onAgentStart?.({ layer: chainConfig.layers.length - 1, agentId: agent.id, agentIndex, input })
         console.log(`📡 [executeAgentChain] Calling model for agent ${agent.id}, copy ${c + 1}`)
         const output = await callModel(
           fullPrompt,
@@ -299,6 +301,7 @@ export async function executeAgentChain(
         const agentOutput = {
           layer: chainConfig.layers.length - 1,
           agentId: agent.id,
+          agentIndex,
           output,
         }
         agentOutputs.push(agentOutput)


### PR DESCRIPTION
## Summary
- include agent index in execution callbacks
- use provided index when updating agent statuses during chain execution

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 127 problems)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68946bb465a083339a4b795f8fd2fec6