### PR TITLE
fix: prevent JSON truncation for market chat

### DIFF
--- a/supabase/functions/market-chat/index.ts
+++ b/supabase/functions/market-chat/index.ts
@@ -247,6 +247,9 @@ In your first reply, surface the most relevant and up-to-date online sources, ci
         type: 'json_schema',
         json_schema: schemaObj
       }
+      // Without an explicit max_output_tokens value OpenRouter will
+      // truncate structured responses to a small default limit.
+      requestBody.max_output_tokens = 8000
     }
     console.log('OpenRouter request body:', requestBody)
     const openRouterResponse = await fetch("https://openrouter.ai/api/v1/chat/completions", {


### PR DESCRIPTION
## Summary
- avoid truncated JSON responses in market chat by specifying `max_output_tokens` when using JSON mode

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 127 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689584b9615c833391e1993e3d020553