### PR TITLE
Add standalone Python script for top market movers

### DIFF
--- a/top_movers.py
+++ b/top_movers.py
@@ -1,0 +1,57 @@
+import argparse
+import os
+import requests
+
+SUPABASE_URL = os.environ.get("SUPABASE_URL", "https://lfmkoismabbhujycnqpn.supabase.co")
+SUPABASE_ANON_KEY = os.environ.get(
+    "SUPABASE_ANON_KEY",
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxmbWtvaXNtYWJiaHVqeWNucXBuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzcwNzQ2NTAsImV4cCI6MjA1MjY1MDY1MH0.OXlSfGb1nSky4rF6IFm1k1Xl-kz7K_u3YgebgP_hBJc",
+)
+
+def fetch_top_movers(interval: int, limit: int = 30, excluded_tags: list[str] | None = None):
+    """Fetch top movers from Supabase function."""
+    url = f"{SUPABASE_URL}/functions/v1/get-top-movers"
+    headers = {
+        "Authorization": f"Bearer {SUPABASE_ANON_KEY}",
+        "Content-Type": "application/json",
+    }
+    payload = {"interval": str(interval), "limit": limit}
+    if excluded_tags:
+        payload["excludedTags"] = excluded_tags
+    response = requests.post(url, headers=headers, json=payload, timeout=30)
+    response.raise_for_status()
+    return response.json().get("data", [])
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Display the top 30 market movers for a given interval (in minutes). "
+            "Exclude markets containing any specified tags."
+        ),
+    )
+    parser.add_argument(
+        "interval",
+        type=int,
+        help="Interval in minutes (e.g., 5, 10, 30, 60, 240, 480, 1440, 10080)",
+    )
+    parser.add_argument(
+        "-e",
+        "--exclude",
+        action="append",
+        default=[],
+        help="Tag to exclude; can be passed multiple times",
+    )
+    args = parser.parse_args()
+
+    movers = fetch_top_movers(args.interval, excluded_tags=args.exclude)
+    if not movers:
+        print("No movers returned.")
+        return
+
+    for idx, market in enumerate(movers, start=1):
+        question = market.get("question") or market.get("market_slug")
+        price_change = market.get("price_change")
+        print(f"{idx}. {question} (Δ {price_change}%)")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `top_movers.py` script to fetch and display top 30 market movers for a specified interval via Supabase function
- allow excluding markets by passing `-e/--exclude` tags which are forwarded as `excludedTags`

## Testing
- `python top_movers.py 60 --exclude politics`
- `npm run lint` *(fails: 107 errors, 20 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68983698babc8333a90d18cafcb3ef56